### PR TITLE
Remove multiprocessing from zoomify_cooler while preserving batch pro…

### DIFF
--- a/src/cooler/_reduce.py
+++ b/src/cooler/_reduce.py
@@ -783,8 +783,9 @@ def zoomify_cooler(
     chunksize : int
         Number of pixels processed at a time per worker.
     nproc : int, optional
-        Number of workers for batch processing of pixels. Default is 1,
-        i.e. no process pool.
+        DEPRECATED: Number of workers for batch processing of pixels.
+        Multiprocessing has been removed in cooler-polars. This parameter
+        is ignored and will be removed in a future version. Default is 1.
     columns : list of str, optional
         Specify which pixel value columns to include in the aggregation.
         Default is to use only the column named 'count' if it exists.
@@ -804,6 +805,16 @@ def zoomify_cooler(
     cooler.merge_coolers
 
     """
+    # Issue deprecation warning for multiprocessing
+    if nproc > 1:
+        warnings.warn(
+            "The 'nproc' parameter is deprecated in cooler-polars. "
+            "Multiprocessing has been removed for better memory management. "
+            "Processing will be done sequentially in batches.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
     # TODO: provide presets? {'pow2', '4dn'}
     if isinstance(base_uris, str):
         base_uris = [base_uris]

--- a/src/cooler/cli/zoomify.py
+++ b/src/cooler/cli/zoomify.py
@@ -11,7 +11,8 @@ from .._reduce import (
     preferred_sequence,
     zoomify_cooler,
 )
-from ..parallel import lock
+
+# lock import removed for cooler-polars
 from ..util import parse_cooler_uri
 from . import cli, get_logger
 from ._util import parse_field_param
@@ -52,8 +53,9 @@ def invoke_balance(args, resolutions, outfile):
     "--nproc",
     "-n",
     "-p",
-    help="Number of processes to use for batch processing chunks of pixels "
-    "[default: 1, i.e. no process pool]",
+    help="DEPRECATED: Number of processes to use for batch processing chunks of "
+    "pixels. Multiprocessing has been removed in cooler-polars. This parameter "
+    "is ignored. [default: 1, i.e. no process pool]",
     default=1,
     type=int,
 )
@@ -142,7 +144,7 @@ def zoomify(
 
     if legacy:
         n_zooms, zoom_levels = legacy_zoomify(
-            cool_uri, outfile, nproc, chunksize, lock=lock
+            cool_uri, outfile, nproc, chunksize
         )
 
         if balance:
@@ -237,7 +239,7 @@ def zoomify(
             resolutions,
             chunksize,
             nproc=nproc,
-            lock=lock,
+            # lock parameter removed for cooler-polars
             columns=columns,
             dtypes=dtypes,
             agg=agg,


### PR DESCRIPTION
…cessing

- Add deprecation warnings for nproc parameter > 1 in zoomify_cooler()
- Remove lock imports and usage from zoomify CLI
- Update CLI help text to indicate nproc is deprecated
- Fix import formatting in zoomify CLI
- All existing functionality preserved, zoomify delegates to coarsen_cooler
- Tests pass with deprecation warnings properly displayed

This continues the cooler-polars transition by removing multiprocessing from zoomify operations while maintaining backward compatibility. The function now relies on the updated coarsen_cooler for sequential processing.

🤖 Generated with [Claude Code](https://claude.ai/code)